### PR TITLE
Fancy urls

### DIFF
--- a/odalc/base/management/commands/send_reminder_emails.py
+++ b/odalc/base/management/commands/send_reminder_emails.py
@@ -16,7 +16,7 @@ class Command(BaseCommand):
         for course in courses_next_day:
             context = {
                 'course': course,
-                'course_url': settings.SITE_URL + reverse('courses:detail', args=(course.id,)),
+                'course_url': settings.SITE_URL + reverse('courses:detail', args=(course.id, course.slug())),
                 'course_date': course.start_datetime.strftime('%A, %B %d'),
                 'course_start_time': course.start_datetime.strftime('%I:%M %p'),
                 'course_end_time': course.end_datetime.strftime('%I:%M %p'),

--- a/odalc/base/views.py
+++ b/odalc/base/views.py
@@ -16,9 +16,17 @@ logger = logging.getLogger(settings.ODALC_LOGGER)
 class AboutPageView(UserDataMixin, TemplateView):
     template_name = 'base/about.html'
 
+    def dispatch(self, request, *args, **kwargs):
+        self.set_perms(request, *args, **kwargs)
+        return super(AboutPageView, self).dispatch(request, *args, **kwargs)
+
 
 class DonatePageView(UserDataMixin, TemplateView):
     template_name = 'base/donate.html'
+
+    def dispatch(self, request, *args, **kwargs):
+        self.set_perms(request, *args, **kwargs)
+        return super(DonatePageView, self).dispatch(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
         context = super(DonatePageView, self).get_context_data(**kwargs)
@@ -48,6 +56,10 @@ class DonatePageView(UserDataMixin, TemplateView):
 class FaqPageView(UserDataMixin, TemplateView):
     template_name = 'base/faq.html'
 
+    def dispatch(self, request, *args, **kwargs):
+        self.set_perms(request, *args, **kwargs)
+        return super(FaqPageView, self).dispatch(request, *args, **kwargs)
+
 
 class HomePageView(UserDataMixin, TemplateView):
     """Landing page for the website. Also displays the next three upcoming
@@ -55,6 +67,10 @@ class HomePageView(UserDataMixin, TemplateView):
     courses as well."""
     NUM_COURSES_SHOWN = 3
     template_name = 'base/home.html'
+
+    def dispatch(self, request, *args, **kwargs):
+        self.set_perms(request, *args, **kwargs)
+        return super(HomePageView, self).dispatch(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
         context = super(HomePageView, self).get_context_data(**kwargs)
@@ -68,8 +84,17 @@ class WorkPageView(UserDataMixin, TemplateView):
     to find partnerships for work opportunities - for potential employees."""
     template_name = 'base/work.html'
 
+    def dispatch(self, request, *args, **kwargs):
+        self.set_perms(request, *args, **kwargs)
+        return super(WorkPageView, self).dispatch(request, *args, **kwargs)
+
 
 class TalentPageView(UserDataMixin, TemplateView):
     """Placeholder page for plans to make this platform open to people wanting
     to find partnerships for work opportunities - for potential employees."""
     template_name = 'base/talent.html'
+
+    def dispatch(self, request, *args, **kwargs):
+        self.set_perms(request, *args, **kwargs)
+        return super(TalentPageView, self).dispatch(request, *args, **kwargs)
+

--- a/odalc/courses/models.py
+++ b/odalc/courses/models.py
@@ -9,6 +9,7 @@ from django.core.validators import (
     RegexValidator
 )
 from django.db import models
+from django.utils.text import slugify
 
 from odalc.users.models import StudentUser
 
@@ -109,7 +110,7 @@ class CourseManager(models.Manager):
         return course
 
 
-# Funnctions for upload paths - issues with Django 1.7 migrations and Python 2.7
+# Functions for upload paths - issues with Django 1.7 migrations and Python 2.7
 # See https://docs.djangoproject.com/en/1.7/topics/migrations/#serializing-values
 def image_upload_path(instance, filename):
     return os.path.join(
@@ -243,6 +244,13 @@ class Course(models.Model):
     )
 
     objects = CourseManager()
+
+    @models.permalink
+    def get_absolute_url(self):
+        return 'courses:detail', (self.id, self.slug())
+
+    def slug(self):
+        return slugify(self.title)
 
     def get_cost_in_cents(self):
         return int(self.cost * 100)

--- a/odalc/courses/urls.py
+++ b/odalc/courses/urls.py
@@ -8,9 +8,9 @@ from odalc.odalc_admin.views import CourseFeedbackView
 from odalc.students.views import SubmitCourseFeedbackView
 
 urlpatterns = patterns('',
-    url(r'^(?P<pk>\d+)/feedback/review/$', CourseFeedbackView.as_view(), name='feedback_review'),
-    url(r'^(?P<pk>\d+)/feedback/$', SubmitCourseFeedbackView.as_view(), name='feedback'),
-    url(r'^(?P<pk>\d+)/edit/$', CourseEditView.as_view(), name='edit'),
-    url(r'^(?P<pk>\d+)/$', CourseDetailView.as_view(), name='detail'),
+    url(r'^(?P<pk>\d+)/(?P<slug>[\w-]+)/feedback/review/$', CourseFeedbackView.as_view(), name='feedback_review'),
+    url(r'^(?P<pk>\d+)/(?P<slug>[\w-]+)/feedback/$', SubmitCourseFeedbackView.as_view(), name='feedback'),
+    url(r'^(?P<pk>\d+)/(?P<slug>[\w-]+)/edit/$', CourseEditView.as_view(), name='edit'),
+    url(r'^(?P<pk>\d+)/(?P<slug>[\w-]+)/$', CourseDetailView.as_view(), name='detail'),
     url(r'^$', CourseListingView.as_view(), name='listing'),
 )

--- a/odalc/odalc_admin/views.py
+++ b/odalc/odalc_admin/views.py
@@ -48,7 +48,7 @@ class ApplicationReviewView(UserDataMixin, UpdateView):
         teacher = course.teacher
         context = {}
         context['course'] = course
-        context['course_url'] = 'http://' + self.request.get_host() + reverse('courses:detail', args=(course.id,))
+        context['course_url'] = 'https://' + self.request.get_host() + reverse('courses:detail', args=(course.id, course.slug()))
         context['facebook_share'] = 'http://www.facebook.com/sharer.php?u=' + context['course_url']
         context['twitter_share'] = 'https://twitter.com/home?status=Check%20out%20this%20new%20course%20that%20just%20went%20live%20at%20Oakland%20Digital!%20'+ context['course_url'] + '%20%23OaklandDigital%20via%20@ODALC'
         context['google_share'] = 'https://plus.google.com/share?url=' + context['course_url']

--- a/odalc/odalc_admin/views.py
+++ b/odalc/odalc_admin/views.py
@@ -34,12 +34,12 @@ class ApplicationReviewView(UserDataMixin, UpdateView):
     template_name = 'odalc_admin/course_application_review.html'
     success_url = reverse_lazy('admins:dashboard')
 
-    def dispatch(self, *args, **kwargs):
-        handler = super(ApplicationReviewView, self).dispatch(*args, **kwargs)
+    def dispatch(self, request, *args, **kwargs):
+        self.set_perms(request, *args, **kwargs)
         if not self.user.is_authenticated():
             return redirect('/users/login?next=%s' % self.request.path)
         elif self.is_admin_user:
-            return handler
+            return super(ApplicationReviewView, self).dispatch(request, *args, **kwargs)
         else:
             return self.deny_access()
 
@@ -108,7 +108,8 @@ class AdminDashboardView(UserDataMixin, ListView):
     TYPE_DENIED = "denied"
 
 
-    def dispatch(self, *args, **kwargs):
+    def dispatch(self, request, *args, **kwargs):
+        self.set_perms(request, *args, **kwargs)
         self.is_active = (self.request.GET.get(AdminDashboardView.PARAM_TYPE)
                             == AdminDashboardView.TYPE_ACTIVE)
         self.is_finished = (self.request.GET.get(AdminDashboardView.PARAM_TYPE)
@@ -118,11 +119,10 @@ class AdminDashboardView(UserDataMixin, ListView):
         self.is_pending = ((self.request.GET.get(AdminDashboardView.PARAM_TYPE)
                             == AdminDashboardView.TYPE_PENDING) or (
                             not self.is_active and not self.is_finished and not self.is_denied))
-        handler = super(AdminDashboardView, self).dispatch(*args, **kwargs)
         if not self.user.is_authenticated():
             return redirect('/users/login?next=%s' % self.request.path)
         elif self.is_admin_user:
-            return handler
+            return super(AdminDashboardView, self).dispatch(request, *args, **kwargs)
         else:
             return self.deny_access()
 
@@ -158,8 +158,8 @@ class AdminDashboardView(UserDataMixin, ListView):
 
 class AJAXAdminDashboardView(View):
     @csrf_exempt
-    def dispatch(self, *args, **kwargs):
-        return super(AJAXAdminDashboardView, self).dispatch(*args, **kwargs)
+    def dispatch(self, request, *args, **kwargs):
+        return super(AJAXAdminDashboardView, self).dispatch(request, *args, **kwargs)
 
     def post(self, request, *args, **kwargs):
         Course.objects.toggle_featured(
@@ -176,13 +176,13 @@ class CourseFeedbackView(UserDataMixin, DetailView):
     template_name = 'odalc_admin/course_feedback.html'
     model = Course
 
-    def dispatch(self, *args, **kwargs):
-        handler = super(CourseFeedbackView, self).dispatch(*args, **kwargs)
+    def dispatch(self, request, *args, **kwargs):
+        self.set_perms(request, *args, **kwargs)
         course = self.get_object()
         if not self.user.is_authenticated():
             return redirect('/users/login?next=%s' % self.request.path)
         elif self.is_admin_user or course.is_owner(self.user):
-            return handler
+            return super(CourseFeedbackView, self).dispatch(request, *args, **kwargs)
         else:
             return self.deny_access()
 
@@ -217,6 +217,10 @@ class AdminEditView(UserDataMixin, UpdateView):
     form_class = AdminEditForm
     success_url = reverse_lazy('admins:dashboard')
 
+    def dispatch(self, request, *args, **kwargs):
+        self.set_perms(request, *args, **kwargs)
+        return super(AdminEditView, self).dispatch(request, *args, **kwargs)
+
     def get_object(self):
         return self.user
 
@@ -231,12 +235,12 @@ class AdminRegisterView(UserDataMixin, CreateView):
     form_class = AdminRegisterForm
     success_url = reverse_lazy('admins:dashboard')
 
-    def dispatch(self, *args, **kwargs):
-        handler = super(AdminRegisterView, self).dispatch(*args, **kwargs)
+    def dispatch(self, request, *args, **kwargs):
+        self.set_perms(request, *args, **kwargs)
         if not self.user.is_authenticated():
             return redirect('/users/login?next=%s' % self.request.path)
         elif self.is_admin_user:
-            return handler
+            return super(AdminRegisterView, self).dispatch(request, *args, **kwargs)
         else:
             return self.deny_access()
 

--- a/odalc/students/views.py
+++ b/odalc/students/views.py
@@ -81,12 +81,11 @@ class SubmitCourseFeedbackView(UserDataMixin, CreateView):
     def form_valid(self, form):
         CourseFeedback.objects.create_from_form(form, self.course.id, self.user.id)
         messages.success(self.request, 'Feedback for submitted')
-        return redirect('courses:detail', self.course.id)
+        return redirect(self.course)
 
     def get_context_data(self, **kwargs):
         context = super(SubmitCourseFeedbackView, self).get_context_data(**kwargs)
-        context['title'] = self.course.title
-        context['pk'] = self.course.pk
+        context['course'] = self.course
         return context
 
 

--- a/odalc/teachers/views.py
+++ b/odalc/teachers/views.py
@@ -23,6 +23,7 @@ class TeacherRegisterView(UserDataMixin, CreateView):
 
     @method_decorator(sensitive_post_parameters('password1', 'password2'))
     def dispatch(self, request, *args, **kwargs):
+        self.set_perms(request, *args, **kwargs)
         if request.user.is_authenticated():
             return redirect('home')
         return super(TeacherRegisterView, self).dispatch(request, *args, **kwargs)
@@ -34,8 +35,8 @@ class TeacherRegisterView(UserDataMixin, CreateView):
     def form_valid(self, form):
         user = form.save()
         login(self.request, authenticate(
-            username=user.email, password=self.request.POST['password1']))
-
+            username=user.email, password=self.request.POST['password1'])
+        )
         messages.success(self.request, 'Successfully registered')
         return super(TeacherRegisterView, self).form_valid(form)
 
@@ -45,6 +46,10 @@ class TeacherEditView(UserDataMixin, UpdateView):
     template_name = "teachers/teacher_edit.html"
     form_class = TeacherEditForm
     success_url = reverse_lazy('teachers:dashboard')
+
+    def dispatch(self, request, *args, **kwargs):
+        self.set_perms(request, *args, **kwargs)
+        return super(TeacherEditView, self).dispatch(request, *args, **kwargs)
 
     def get_object(self):
         return self.user
@@ -59,6 +64,10 @@ class CreateCourseView(UserDataMixin, FormView):
     template_name = 'teachers/create_course_form.html'
     form_class = CreateCourseForm
     success_url = reverse_lazy('teachers:dashboard')
+
+    def dispatch(self, request, *args, **kwargs):
+        self.set_perms(request, *args, **kwargs)
+        return super(CreateCourseView, self).dispatch(request, *args, **kwargs)
 
     def form_valid(self, form):
         # Create a new Course Instance
@@ -83,6 +92,10 @@ class CreateCourseView(UserDataMixin, FormView):
 
 class TeacherDashboardView(UserDataMixin, TemplateView):
     template_name = "teachers/dashboard.html"
+
+    def dispatch(self, request, *args, **kwargs):
+        self.set_perms(request, *args, **kwargs)
+        return super(TeacherDashboardView, self).dispatch(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
         context = super(TeacherDashboardView, self).get_context_data(**kwargs)

--- a/odalc/templates/base/home.html
+++ b/odalc/templates/base/home.html
@@ -50,7 +50,7 @@
     <div class="row course-items">
         {% for course in featured_courses %}
         <div class="course-box">
-            <a href="{% url "courses:detail" course.pk %}">
+            <a href="{% url "courses:detail" course.pk course.slug %}">
                 <div class="top-shelf">
                     <div class="title-wrap">
                         <h4>{{ course.title }}</h4>

--- a/odalc/templates/base/partials/course_tile.html
+++ b/odalc/templates/base/partials/course_tile.html
@@ -1,5 +1,5 @@
 <div class="course-tile">
-    <a href="{% url "courses:detail" course.pk %}">
+    <a href="{% url "courses:detail" course.pk course.slug %}">
     <div class="row">
         <div class="medium-4 medium-push-8 columns">
             <img class="course-thumbnail" src="{{ course.image_thumbnail.url }}"></img>

--- a/odalc/templates/courses/course.html
+++ b/odalc/templates/courses/course.html
@@ -34,7 +34,7 @@ fjs.parentNode.insertBefore(js, fjs);
                 {% if in_class %}
                     {% if is_past_start_date %}
                         {% if not submitted_feedback %}
-                        <form action="{% url "courses:feedback" course.id %}" method="GET">
+                        <form action="{% url "courses:feedback" course.id course.slug %}" method="GET">
                             <button class="enroll-btn">Submit Feedback</button>
                         </form>
                         {% else %}

--- a/odalc/templates/odalc_admin/course_tile_action_active.html
+++ b/odalc/templates/odalc_admin/course_tile_action_active.html
@@ -8,7 +8,7 @@
             {% endif %}
         </div>
         <div class="small-6 medium-3 columns">
-            <a class="action-button" href="{% url "courses:edit" course.pk %}">Edit course info</a>
+            <a class="action-button" href="{% url "courses:edit" course.pk course.slug %}">Edit course info</a>
         </div>
     </div>
 </div>

--- a/odalc/templates/odalc_admin/course_tile_action_denied.html
+++ b/odalc/templates/odalc_admin/course_tile_action_denied.html
@@ -1,7 +1,7 @@
 <div class="course-tile-action">
     <div class="row">
         <div class="medium-4 medium-offset-8 columns">
-            <a class="action-button" href="{% url "courses:edit" course.pk %}">Edit course info</a>
+            <a class="action-button" href="{% url "courses:edit" course.pk course.slug %}">Edit course info</a>
         </div>
     </div>
 </div>

--- a/odalc/templates/odalc_admin/course_tile_action_finished.html
+++ b/odalc/templates/odalc_admin/course_tile_action_finished.html
@@ -1,10 +1,10 @@
 <div class="course-tile-action">
     <div class="row">
         <div class="small-6 medium-4 medium-offset-5 columns">
-            <a class="action-button" href="{% url "courses:feedback_review" course.pk %}">View course feedback</a>
+            <a class="action-button" href="{% url "courses:feedback_review" course.pk course.slug %}">View course feedback</a>
         </div>
         <div class="small-6 medium-3 columns">
-            <a class="action-button" href="{% url "courses:edit" course.pk %}">Edit course info</a>
+            <a class="action-button" href="{% url "courses:edit" course.pk course.slug %}">Edit course info</a>
         </div>
     </div>
 </div>

--- a/odalc/templates/students/course_feedback_form.html
+++ b/odalc/templates/students/course_feedback_form.html
@@ -4,7 +4,7 @@
 {% block body %}
 <div class='row'>
 	<h1>Feedback for {{ title }}</h1>
-	<form action="{% url "courses:feedback" pk %}" method="POST" class='large-12 columns'>
+	<form action="{% url "courses:feedback" course.pk course.slug %}" method="POST" class='large-12 columns'>
 	  {% csrf_token %}
 	  <ul class='form-list'>
 	    {{ form.as_ul }}

--- a/odalc/templates/students/student_dashboard.html
+++ b/odalc/templates/students/student_dashboard.html
@@ -24,7 +24,7 @@
                         </tr>
                     {% for course in courses_upcoming %}
                         <tr>
-                            <td><a href="{% url "courses:detail" course.pk %}"> {{ course.title }}</a></td>
+                            <td><a href="{% url "courses:detail" course.pk course.slug %}"> {{ course.title }}</a></td>
                             <td>{{ course.teacher.first_name }} {{ course.teacher.last_name }}</td>
                             <td class="right">{{ course.start_datetime|date:'D, N d Y' }} | {{ course.start_datetime|date:'P'}} - {{ course.end_datetime|date:'P' }}</td>
                         </tr>
@@ -47,7 +47,7 @@
                         </tr>
                     {% for course in courses_taken %}
                         <tr>
-                            <td> <a href="{% url "courses:detail" course.pk %}"> {{ course.title }}</a> </td>
+                            <td> <a href="{% url "courses:detail" course.pk course.slug %}"> {{ course.title }}</a> </td>
                             <td> {{ course.teacher.first_name }} {{ course.teacher.last_name }} </td>
                             <td class="right">{{ course.start_datetime|date:'D, N d Y' }} | {{ course.start_datetime|date:'P'}} - {{ course.end_datetime|date:'P' }}</td>
                         </tr>

--- a/odalc/templates/teachers/dashboard.html
+++ b/odalc/templates/teachers/dashboard.html
@@ -25,8 +25,8 @@
                     <tbody>
                     {% for course in pending_courses %}
                     <tr>
-                        <td><a href="{% url "courses:detail" course.pk %}">{{ course.title }}</a></td>
-                        <td><a href="{% url "courses:edit" course.pk %}">Edit course page &raquo;</a></td>
+                        <td><a href="{% url "courses:detail" course.pk course.slug %}">{{ course.title }}</a></td>
+                        <td><a href="{% url "courses:edit" course.pk course.slug %}">Edit course page &raquo;</a></td>
                     </tr>
                     {% empty %}
                     <tr><td>No courses pending.</td></tr>
@@ -48,8 +48,8 @@
                     <tbody>
                     {% for course in active_courses %}
                     <tr>
-                        <td><a href="{% url "courses:detail" course.pk %}">{{ course.title }}</a></td>
-                        <td><a href="{% url "courses:edit" course.pk %}">Edit course page &raquo;</a></td>
+                        <td><a href="{% url "courses:detail" course.pk course.slug %}">{{ course.title }}</a></td>
+                        <td><a href="{% url "courses:edit" course.pk course.slug %}">Edit course page &raquo;</a></td>
                     </tr>
                     {% empty %}
                     <tr><td>No courses active.</td></tr>
@@ -72,9 +72,9 @@
                     <tbody>
                     {% for course in finished_courses %}
                     <tr>
-                        <td><a href="{% url "courses:detail" course.pk %}">{{ course.title }}</a></td>
-                        <td><a href="{% url "courses:feedback_review" course.pk %}">View course feedback &raquo;</a></td>
-                        <td><a href="{% url "courses:edit" course.pk %}">Edit course page &raquo;</a></td>
+                        <td><a href="{% url "courses:detail" course.pk course.slug %}">{{ course.title }}</a></td>
+                        <td><a href="{% url "courses:feedback_review" course.pk course.slug %}">View course feedback &raquo;</a></td>
+                        <td><a href="{% url "courses:edit" course.pk course.slug %}">Edit course page &raquo;</a></td>
                     </tr>
                     {% empty %}
                     <tr><td>No courses yet.</td></tr>
@@ -97,8 +97,8 @@
                     <tbody>
                     {% for course in denied_courses %}
                     <tr>
-                        <td><a href="{% url "courses:detail" course.pk %}">{{ course.title }}</a></td>
-                        <td><a href="{% url "courses:edit" course.pk %}">Edit course page &raquo;</a></td>
+                        <td><a href="{% url "courses:detail" course.pk course.slug %}">{{ course.title }}</a></td>
+                        <td><a href="{% url "courses:edit" course.pk course.slug %}">Edit course page &raquo;</a></td>
                     </tr>
                     {% endfor %}
                     </tbody>


### PR DESCRIPTION
Add course title slug for URLS (but just for human readability).
Also clean up permissions handling in the `dispatch` methods on the views. It's repeating code a little, but I'd prefer that over the weird order of logic that was there in the `dispatch` methods before, which sometimes resulted in requests being processed twice.